### PR TITLE
Unify data type for time variables

### DIFF
--- a/examples/ESP8266/ChannelStatistics/ChannelStatistics.ino
+++ b/examples/ESP8266/ChannelStatistics/ChannelStatistics.ino
@@ -23,8 +23,8 @@ char password[] = "yyyy";  // your network key
 WiFiClientSecure client;
 YoutubeApi api(API_KEY, client);
 
-int api_mtbs = 60000; //mean time between api requests
-long api_lasttime;   //last time api request has been done
+unsigned long api_mtbs = 60000; //mean time between api requests
+unsigned long api_lasttime;   //last time api request has been done
 
 long subs = 0;
 
@@ -57,7 +57,7 @@ void setup() {
 
 void loop() {
 
-  if (millis() > api_lasttime + api_mtbs)  {
+  if (millis() - api_lasttime > api_mtbs)  {
     if(api.getChannelStatistics(CHANNEL_ID))
     {
       Serial.println("---------Stats---------");


### PR DESCRIPTION
The three variables used in the main loop were all different data types, which would likely cause roll-over issues at ~25 or ~50 days of run time.

This fix changes the api_mtbs and api_lasttime to match the unsigned long type used by the millis() function and tweaks the main loop comparison.

I will admit I haven't produced the original possible issue or tested the fix, since it would take several months to do so. At the very least, the time variables are now the same datatype.