### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Use this library to get YouTube channel statistics
 category=Communication
 url=https://github.com/witnessmenow/arduino-youtube-api
 architectures=*
+depends=ArduinoJson


### PR DESCRIPTION
Specifying the library dependencies in the depends field of library.properties causes Library Manager to offer to install the dependencies during installation of this library.