### PR TITLE
Travis CI Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 
 env:
     - SCRIPT=platformioSingle EXAMPLE_NAME=ChannelStatistics EXAMPLE_FOLDER=/ BOARDTYPE=ESP8266 BOARD=d1_mini
+    - SCRIPT=platformioSingle EXAMPLE_NAME=ChannelStatistics EXAMPLE_FOLDER=/ BOARDTYPE=ESP32 BOARD=tinypico
 
 install:
     - pip install -U platformio

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ cache:
 
 env:
     - SCRIPT=platformioSingle EXAMPLE_NAME=ChannelStatistics EXAMPLE_FOLDER=/ BOARDTYPE=ESP8266 BOARD=d1_mini
-    - SCRIPT=platformioSingle EXAMPLE_NAME=ChannelStatisticsWithWifiManager EXAMPLE_FOLDER=/ BOARDTYPE=ESP8266 BOARD=d1_mini
-    - SCRIPT=platformioSingle EXAMPLE_NAME=ChannelStatisticsWithWifiManagerAndDoubleReset EXAMPLE_FOLDER=/ BOARDTYPE=ESP8266 BOARD=d1_mini
-
 
 install:
     - pip install -U platformio


### PR DESCRIPTION
This PR fixes the Travis CI integration by removing the two examples that no longer exist and adding support for the ESP32 example (compiling for the TinyPICO).