### PR TITLE
Deprecate channel coment count

### DIFF
--- a/examples/ESP32/ChannelStatistics/ChannelStatistics.ino
+++ b/examples/ESP32/ChannelStatistics/ChannelStatistics.ino
@@ -89,8 +89,6 @@ void loop() {
       Serial.println(api.channelStats.subscriberCount);
       Serial.print("View Count: ");
       Serial.println(api.channelStats.viewCount);
-      Serial.print("Comment Count: ");
-      Serial.println(api.channelStats.commentCount);
       Serial.print("Video Count: ");
       Serial.println(api.channelStats.videoCount);
       // Probably not needed :)

--- a/examples/ESP8266/ChannelStatistics/ChannelStatistics.ino
+++ b/examples/ESP8266/ChannelStatistics/ChannelStatistics.ino
@@ -95,8 +95,6 @@ void loop() {
       Serial.println(api.channelStats.subscriberCount);
       Serial.print("View Count: ");
       Serial.println(api.channelStats.viewCount);
-      Serial.print("Comment Count: ");
-      Serial.println(api.channelStats.commentCount);
       Serial.print("Video Count: ");
       Serial.println(api.channelStats.videoCount);
       // Probably not needed :)

--- a/src/YoutubeApi.h
+++ b/src/YoutubeApi.h
@@ -33,7 +33,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 struct channelStatistics{
   long viewCount;
-  long commentCount;
+  long commentCount; /* DEPRECATED */
   long subscriberCount;
   bool hiddenSubscriberCount;
   long videoCount;


### PR DESCRIPTION
As of September 9th, 2020 this resource property has been deprecated. The API still returns the value in JSON, but I tested with a number of channels, large and small, and they all report '0' for the `commentCount` field. See https://developers.google.com/youtube/v3/revision_history#september-9,-2020 for more info.

Because of this I've removed the `commentCount` print from both examples. `ArduinoJSON` gracefully handles missing values by reporting them as '0', so the struct value and parser can remain as is until the next major library release (3.0).